### PR TITLE
fixed makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,3 @@
 all:
-	latexpdf Consistent_Draft.tex 
+	pdflatex Consistent_Draft.tex 
 


### PR DESCRIPTION
Corrected makefile to work with pdflatex.
See Dr. J's makefile for an example of how to alter the makefile to include the use case diagram/diagrams when we have generated PNG files:

https://github.com/cjeffery/sworsorc/blob/811b44fc632ee7925a10587b9838ce1ade78007d/doc/hw3/B/Makefile
